### PR TITLE
Optimize docker containerization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.17.7-bullseye
+FROM golang:1.17.7-alpine
 
 ENV LANG=C.UTF-8
-RUN apt-get update && apt-get install -qq -y postgresql-client
+RUN apk update && apk add --no-cache postgresql-client
 
 ENV app /app
 RUN mkdir -p $app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: "postgres:13.3"
+    image: "postgres:13-alpine"
     restart: always
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   db:
     image: "postgres:13.3"
@@ -40,7 +39,6 @@ services:
       - db
     links:
       - db
-    restart: always
     env_file:
       - .env
     logging:


### PR DESCRIPTION
- use alpine for a lighter image 
bullseye-based image: 1.02 GB
alpine-based image: 374 MB
![image](https://github.com/emad-elsaid/library/assets/52883485/94ec27a8-0389-42ce-9241-1ef9241263bb)

- remove extra `restart` key from docker compose file


room for improvement that I might implement later
docker images for 1.17 known to have some vulnerabilities that are mitigated in the newer images eg. 1.19, 1.20
![image](https://github.com/emad-elsaid/library/assets/52883485/76c2bfae-9a25-4a1c-86a6-c23cce1e19b9)

also this could be a multi-stage docker layers so the final image is just alpine running a go binary
// Build stage
FROM golang:1.20-alpine3.18 AS builder
// Run stage
FROM alpine:3.18 
